### PR TITLE
♻️ update(workflows): Modify Jenkins trigger workflow to support all branches on push

### DIFF
--- a/.github/workflows/jenkins-trigger-yml.backup
+++ b/.github/workflows/jenkins-trigger-yml.backup
@@ -1,29 +1,47 @@
-name: Trigger Jenkins Job
+name: Trigger Jenkins Job (Testing)
 
 on:
   push:
     branches:
-      - '**'  # This will trigger the workflow on any branch that receives a push
-  workflow_dispatch:  # This allows the workflow to be manually triggered if needed
+      - "dev-v2" # Only push to dev branch
+  pull_request:
+    branches:
+      - "dev-v2" # Only PRs to dev
+  workflow_dispatch: # Also manual
 
 jobs:
   trigger-job:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Get the branch name and build the URL for Jenkins
-      - name: Get branch name and build Jenkins URL
+      # Get and trigger BACKEND
+      - name: Get branch name and build Backend Jenkins URL
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
-          JENKINS_URL="https://automation.prms.cgiar.org/job/qa-application-${BRANCH_NAME}/build"
-          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
-          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
-        
-      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
-      - name: Trigger Jenkins Job
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_BACKEND_URL="https://automation.prms.cgiar.org/job/prms-qa-dev-server-docker/build"
+          echo "Backend Jenkins URL: $JENKINS_BACKEND_URL"
+          echo "JENKINS_BACKEND_URL=${JENKINS_BACKEND_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Backend Jenkins Job
         run: |
-          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+          curl -X POST ${{ env.JENKINS_BACKEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
         env:
-          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_BACKEND_URL: ${{ env.JENKINS_BACKEND_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+
+      # Get and trigger FRONTEND
+      - name: Get branch name and build Frontend Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_FRONTEND_URL="https://automation.prms.cgiar.org/job/prms-qa-dev-client-docker/build"
+          echo "Frontend Jenkins URL: $JENKINS_FRONTEND_URL"
+          echo "JENKINS_FRONTEND_URL=${JENKINS_FRONTEND_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Frontend Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_FRONTEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_FRONTEND_URL: ${{ env.JENKINS_FRONTEND_URL }}
           JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,47 +1,29 @@
-name: Trigger Jenkins Job (Testing)
+name: Trigger Jenkins Job
 
 on:
   push:
     branches:
-      - "dev-v2" # Only push to dev branch
-  pull_request:
-    branches:
-      - "dev-v2" # Only PRs to dev
-  workflow_dispatch: # Also manual
+      - '**'  # This will trigger the workflow on any branch that receives a push
+  workflow_dispatch:  # This allows the workflow to be manually triggered if needed
 
 jobs:
   trigger-job:
     runs-on: ubuntu-latest
 
     steps:
-      # Get and trigger BACKEND
-      - name: Get branch name and build Backend Jenkins URL
+      # Step 1: Get the branch name and build the URL for Jenkins
+      - name: Get branch name and build Jenkins URL
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          JENKINS_BACKEND_URL="https://automation.prms.cgiar.org/job/prms-qa-dev-server-docker/build"
-          echo "Backend Jenkins URL: $JENKINS_BACKEND_URL"
-          echo "JENKINS_BACKEND_URL=${JENKINS_BACKEND_URL}" >> $GITHUB_ENV
-
-      - name: Trigger Backend Jenkins Job
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/qa-application-${BRANCH_NAME}/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+        
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+      - name: Trigger Jenkins Job
         run: |
-          curl -X POST ${{ env.JENKINS_BACKEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
         env:
-          JENKINS_BACKEND_URL: ${{ env.JENKINS_BACKEND_URL }}
-          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
-          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
-
-      # Get and trigger FRONTEND
-      - name: Get branch name and build Frontend Jenkins URL
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          JENKINS_FRONTEND_URL="https://automation.prms.cgiar.org/job/prms-qa-dev-client-docker/build"
-          echo "Frontend Jenkins URL: $JENKINS_FRONTEND_URL"
-          echo "JENKINS_FRONTEND_URL=${JENKINS_FRONTEND_URL}" >> $GITHUB_ENV
-
-      - name: Trigger Frontend Jenkins Job
-        run: |
-          curl -X POST ${{ env.JENKINS_FRONTEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
-        env:
-          JENKINS_FRONTEND_URL: ${{ env.JENKINS_FRONTEND_URL }}
+          JENKINS_URL: ${{ env.JENKINS_URL }}
           JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request includes updates to two GitHub Actions workflow files to refine the Jenkins job triggering process. The changes include creating a backup workflow (`jenkins-trigger-yml.backup`) with a more specific branch and job configuration and restoring the original workflow (`jenkins-trigger.yml`) to its previous, more generic configuration.

### Workflow modifications:

#### Backup workflow (`.github/workflows/jenkins-trigger-yml.backup`):
* Updated the workflow to trigger only on pushes and pull requests to the `dev-v2` branch, and retained manual triggering via `workflow_dispatch`.
* Split the Jenkins job triggering process into separate steps for the backend and frontend, each with its own dynamically constructed URL and trigger logic.

#### Original workflow (`.github/workflows/jenkins-trigger.yml`):
* Reverted the workflow to trigger on any branch push and allow manual triggering via `workflow_dispatch`.
* Simplified the Jenkins job triggering process to use a single dynamically constructed URL for the branch, removing the separate backend and frontend steps.